### PR TITLE
Fixing write_to writing the incorrect byte position for the upper bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 *.mmdb
+.idea

--- a/maxminddb-writer/src/node.rs
+++ b/maxminddb-writer/src/node.rs
@@ -47,10 +47,10 @@ impl Node {
             ]),
             // 28 bits/ptr -> 7 bytes
             RecordSize::Medium => writer.write_all(&[
-                (ptrs[0] >> 20) as u8,
-                (ptrs[0] >> 12) as u8,
-                (ptrs[0] >> 4) as u8,
-                (ptrs[0] << 4) as u8 | (ptrs[1] >> 24) as u8,
+                (ptrs[0] >> 16) as u8,
+                (ptrs[0] >> 8) as u8,
+                ptrs[0] as u8,
+                (((ptrs[0] >> 24) << 4) | (ptrs[1] >> 24)) as u8, // Shared middle byte
                 (ptrs[1] >> 16) as u8,
                 (ptrs[1] >> 8) as u8,
                 ptrs[1] as u8,
@@ -151,6 +151,7 @@ impl Default for NodeTree {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Database;
 
     #[test]
     fn test_insert_to_empty() {


### PR DESCRIPTION
# Title: Patch for Issue #3 

## Summary

While operating our `mmdb` file started failing with invalid data responses, in investigating we found that when our `mmdb` would change from a `RecordSize::Small` to `RecordSize::Medium` we would consistently fail with any query mapping to the same memory address. In looking the root cause looks to be the bitshift logic being off by 4 bits on the upper byte with it taking bits `27 .. 4` instead of `23 .. 0` and using bytes `3..0` instead of `27..24` for the shared middle byte. 

<img width="530" height="113" alt="image" src="https://github.com/user-attachments/assets/6f73c967-e21f-46a4-a631-4bb174643b16" />


## Changes

- Updated `Node::write_to` function to write bytes in the correct order 
- Added explicit tests on the `Database` struct to ensure a write and read from each Record Size is possible

## Additional Notes

To further confirm my understanding of the spec I have referenced two other implementations of MMDB writers, the official [Go Replacement](https://github.com/maxmind/mmdbwriter/blob/9da97f5707cb3df4139dd37a4cc4ea3682cd980d/tree.go#L608-L615) and another custom implementation [in Python](https://github.com/vimt/MaxMind-DB-Writer-python/blob/master/mmdb_writer.py#L509-L517) that shift the first byte in the same way as my patch. 
